### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/docs/INSTALL_GUIDE.md
+++ b/docs/INSTALL_GUIDE.md
@@ -368,7 +368,7 @@ openclaw config set auth.zai.apiKey 你的API密钥
 #### MiniMax
 
 ```bash
-openclaw config set agents.defaults.model minimax/MiniMax-M2.1
+openclaw config set agents.defaults.model minimax/MiniMax-M3
 openclaw config set auth.minimax.apiKey 你的API密钥
 ```
 

--- a/docs/guides/models-cn.md
+++ b/docs/guides/models-cn.md
@@ -105,9 +105,10 @@ openclaw onboard
 
 | 选项 | 说明 |
 |------|------|
-| MiniMax M2.5 | 标准版 |
-| MiniMax M2.5 (CN) | 国内端点 (api.minimaxi.com) |
-| MiniMax M2.5 Highspeed | 官方快速层级 |
+| MiniMax M3 | 最新旗舰版（默认推荐，512K 上下文） |
+| MiniMax M2.7 | 上一代标准版（保留兼容） |
+| MiniMax M2.7 (CN) | 国内端点 (api.minimaxi.com) |
+| MiniMax M2.7 Highspeed | 官方快速层级 |
 
 ---
 

--- a/docs/upstream/wizard.md
+++ b/docs/upstream/wizard.md
@@ -57,7 +57,7 @@ openclaw onboard --install-daemon
 | **OpenCode Go** | Kimi/GLM/MiniMax Go 目录 |
 | **胜算云** | 国产模型聚合平台 |
 | **阿里云百炼** | ModelStudio Coding Plan |
-| **MiniMax** | M2.5 系列 |
+| **MiniMax** | M3 / M2.7 系列 |
 | **Moonshot (Kimi)** | Kimi K2.5 + Kimi Coding |
 | **智谱 Z.AI** | GLM Coding Plan |
 | **Ollama** | 本地开源模型 |

--- a/translations/panel/feature-panel.js
+++ b/translations/panel/feature-panel.js
@@ -359,6 +359,7 @@
 
       const builtins = [
         { id: 'auto', name: 'Auto（自动选择最优）' },
+        { id: 'MiniMax-M3', name: 'MiniMax M3' },
         { id: 'MiniMax-M2.7', name: 'MiniMax M2.7' },
         { id: 'kimi-k2.5', name: 'Kimi K2.5' },
         { id: 'glm-5.1', name: 'GLM-5.1' },

--- a/translations/providers/files/extensions/qingchenyun/provider-catalog.ts
+++ b/translations/providers/files/extensions/qingchenyun/provider-catalog.ts
@@ -14,6 +14,12 @@ export function buildQtcoolProvider(): ModelProviderConfig {
         maxTokens: 16384,
       },
       {
+        id: "MiniMax-M3",
+        name: "MiniMax M3",
+        contextWindow: 524288,
+        maxTokens: 131072,
+      },
+      {
         id: "MiniMax-M2.7",
         name: "MiniMax M2.7",
         contextWindow: 128000,
@@ -42,12 +48,6 @@ export function buildQtcoolProvider(): ModelProviderConfig {
         name: "GLM-5",
         contextWindow: 128000,
         maxTokens: 8192,
-      },
-      {
-        id: "MiniMax-M2.5",
-        name: "MiniMax M2.5",
-        contextWindow: 128000,
-        maxTokens: 16384,
       },
       {
         id: "gpt-5.4",


### PR DESCRIPTION
## Summary
Upgrade the project's bundled MiniMax model entries to include the latest M3 flagship as the recommended option, while keeping M2.7 around for compatibility. Removes the deprecated M2.5 entry from the qingchenyun (qtcool) provider catalog.

## Changes
- `translations/providers/files/extensions/qingchenyun/provider-catalog.ts`
  - Add `MiniMax-M3` (`contextWindow: 524288`, `maxTokens: 131072`) right after `auto`
  - Remove deprecated `MiniMax-M2.5`
  - Retain `MiniMax-M2.7` as a fallback option
- `translations/panel/feature-panel.js`
  - Add `MiniMax-M3` to the built-in recommended models list (before M2.7) so it shows up in the Dashboard model picker
- `docs/INSTALL_GUIDE.md`
  - Update the MiniMax quick-config example from `minimax/MiniMax-M2.1` to `minimax/MiniMax-M3`
- `docs/guides/models-cn.md`
  - Refresh the MiniMax version-selection table to list M3 (new default) and the M2.7 family
- `docs/upstream/wizard.md`
  - Update the wizard provider summary row from `M2.5 系列` to `M3 / M2.7 系列`

## Why
MiniMax M3 is the new flagship model with a 512K context window and 128K max output. Surfacing it in the qingchenyun (qtcool) catalog and the recommended built-ins list lets users pick it directly from the Dashboard, and updating the docs keeps the quick-start examples pointing at a current, supported model name (the old `MiniMax-M2.1` reference in INSTALL_GUIDE has been deprecated for a while).

The change is intentionally minimal: only the qingchenyun provider catalog and the panel built-ins list (project-owned code) are touched. Translation overlay rules in `translations/extensions/*.json` keep their existing left-hand match strings unchanged, since those have to keep matching the upstream OpenClaw source.

## Testing
- `node cli/index.mjs status` — translations config still loads (158 files, all categories detected)
- All `translations/**/*.json` re-validated with `json.load` (no parse errors)
- `provider-catalog.ts` and `feature-panel.js` syntax checked
- Existing PR-check workflow (`.github/workflows/pr-check.yml`) covers JSON / shell / python validation