### PR TITLE
Add MiniMax M3 to model recommendations

### DIFF
--- a/docs/guides/models-cn.md
+++ b/docs/guides/models-cn.md
@@ -105,11 +105,75 @@ openclaw onboard
 
 | 选项 | 说明 |
 |------|------|
-| MiniMax M3 | 推荐版；100 万上下文；支持国际端点 (api.minimax.io) 与国内端点 (api.minimaxi.com) |
-| MiniMax M2.7 | 高性能版；20.48 万上下文 |
+| MiniMax M3 | Recommended; 1,000,000-token context window; text, image, and video input; adaptive or disabled thinking |
+| MiniMax M2.7 | 204,800-token context window; text input; thinking always enabled |
 | MiniMax M2.5 | 标准版 |
 | MiniMax M2.5 (CN) | 国内端点 (api.minimaxi.com) |
 | MiniMax M2.5 Highspeed | 官方快速层级 |
+
+### API pricing
+
+Prices are in USD per million tokens. A dash means the official pricing page does not list a cache-write rate.
+
+| Model | Service tier | Input-token range | Input | Output | Cache read | Cache write |
+|-------|--------------|-------------------|-------|--------|------------|-------------|
+| MiniMax M3 | Standard | Up to 512,000 | 0.30 | 1.20 | 0.06 | - |
+| MiniMax M3 | Standard | Over 512,000 | 0.60 | 2.40 | 0.12 | - |
+| MiniMax M3 | Priority | Up to 512,000 | 0.45 | 1.80 | 0.09 | - |
+| MiniMax M3 | Priority | Over 512,000 | 0.90 | 3.60 | 0.18 | - |
+| MiniMax M2.7 | Standard | All input lengths | 0.30 | 1.20 | 0.06 | 0.375 |
+
+See the [official pay-as-you-go pricing](https://platform.minimax.io/docs/guides/pricing-paygo) for current rates.
+
+### Compatible API configuration
+
+Use the matching `baseUrl` and `api` values for the required region and protocol:
+
+| Region | `openai-completions` | `anthropic-messages` |
+|--------|----------------------|----------------------|
+| Global | `https://api.minimax.io/v1` | `https://api.minimax.io/anthropic` |
+| China | `https://api.minimaxi.com/v1` | `https://api.minimaxi.com/anthropic` |
+
+OpenClaw appends `/chat/completions` to an OpenAI-compatible base URL and `/v1/messages` to an Anthropic-compatible base URL. Do not append `/v1` to the Anthropic-compatible base URL.
+See the official [OpenAI-compatible API](https://platform.minimax.io/docs/api-reference/text-openai-api) and [Anthropic-compatible API](https://platform.minimax.io/docs/api-reference/text-anthropic-api) documentation for protocol details.
+
+```json
+{
+  "models": {
+    "mode": "merge",
+    "providers": {
+      "minimax-custom": {
+        "baseUrl": "https://api.minimax.io/anthropic",
+        "api": "anthropic-messages",
+        "apiKey": "${MINIMAX_API_KEY}",
+        "models": [
+          {
+            "id": "MiniMax-M3",
+            "name": "MiniMax M3",
+            "reasoning": true,
+            "input": ["text", "image", "video"],
+            "contextWindow": 1000000
+          },
+          {
+            "id": "MiniMax-M2.7",
+            "name": "MiniMax M2.7",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 204800
+          }
+        ]
+      }
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": "minimax-custom/MiniMax-M3"
+      }
+    }
+  }
+}
+```
 
 ---
 

--- a/docs/guides/models-cn.md
+++ b/docs/guides/models-cn.md
@@ -105,6 +105,8 @@ openclaw onboard
 
 | 选项 | 说明 |
 |------|------|
+| MiniMax M3 | 推荐版；100 万上下文；支持国际端点 (api.minimax.io) 与国内端点 (api.minimaxi.com) |
+| MiniMax M2.7 | 高性能版；20.48 万上下文 |
 | MiniMax M2.5 | 标准版 |
 | MiniMax M2.5 (CN) | 国内端点 (api.minimaxi.com) |
 | MiniMax M2.5 Highspeed | 官方快速层级 |

--- a/translations/panel/feature-panel.js
+++ b/translations/panel/feature-panel.js
@@ -359,6 +359,7 @@
 
       const builtins = [
         { id: 'auto', name: 'Auto（自动选择最优）' },
+        { id: 'MiniMax-M3', name: 'MiniMax M3' },
         { id: 'MiniMax-M2.7', name: 'MiniMax M2.7' },
         { id: 'kimi-k2.5', name: 'Kimi K2.5' },
         { id: 'glm-5.1', name: 'GLM-5.1' },

--- a/translations/providers/files/extensions/qingchenyun/provider-catalog.ts
+++ b/translations/providers/files/extensions/qingchenyun/provider-catalog.ts
@@ -14,9 +14,15 @@ export function buildQtcoolProvider(): ModelProviderConfig {
         maxTokens: 16384,
       },
       {
+        id: "MiniMax-M3",
+        name: "MiniMax M3",
+        contextWindow: 1000000,
+        maxTokens: 16384,
+      },
+      {
         id: "MiniMax-M2.7",
         name: "MiniMax M2.7",
-        contextWindow: 128000,
+        contextWindow: 204800,
         maxTokens: 16384,
       },
       {


### PR DESCRIPTION
Reason: MiniMax-capable model registry includes MiniMax-M2.7 but is missing MiniMax-M3 from the target top models.

## Summary
- Add MiniMax-M3 ahead of MiniMax-M2.7 in the Qingchen provider model catalog.
- Correct the MiniMax-M2.7 context window and add MiniMax-M3 to the feature panel recommendations.
- Document both target models, complete tiered pricing, and global/China OpenAI- and Anthropic-compatible endpoint configuration.

## Checks
- node --check translations/panel/feature-panel.js
- jq empty for all translation JSON files and package.json
- Runtime catalog assertion for model order and context windows
- Documentation example validated with openclaw config validate on OpenClaw 2026.6.11
- Request captures for global/China OpenAI Chat Completions and Anthropic Messages paths
