### PR TITLE
Add MiniMax M3 and M2.7 to CiyAPI model recommendations

### DIFF
--- a/docs/guides/models-cn.md
+++ b/docs/guides/models-cn.md
@@ -105,9 +105,9 @@ openclaw onboard
 
 | 选项 | 说明 |
 |------|------|
-| MiniMax M2.5 | 标准版 |
-| MiniMax M2.5 (CN) | 国内端点 (api.minimaxi.com) |
-| MiniMax M2.5 Highspeed | 官方快速层级 |
+| MiniMax M3 | 最新旗舰版（默认推荐，100 万 token 上下文） |
+| MiniMax M2.7 | 标准版（204,800 token 上下文） |
+| MiniMax M2.7 (CN) | 国内端点 (api.minimaxi.com) |
 
 ---
 

--- a/tests/node/ciyapi-sponsor.test.mjs
+++ b/tests/node/ciyapi-sponsor.test.mjs
@@ -86,3 +86,16 @@ test("CiyAPI setup does not read or overwrite the old provider configuration", a
   assert.match(onboard, /applyProviderConfig/);
   assert.match(onboard, /applyConfig/);
 });
+
+test("CiyAPI model catalog and panel recommend MiniMax M3 and M2.7", async () => {
+  const panel = await text("translations/panel/feature-panel.js");
+  const catalog = await text("translations/providers/files/extensions/qingchenyun/provider-catalog.ts");
+
+  for (const id of ["MiniMax-M3", "MiniMax-M2.7"]) {
+    assert.match(catalog, new RegExp(`id: "${id}"`));
+    assert.match(panel, new RegExp(`id: '${id}'`));
+  }
+
+  assert.match(catalog, /contextWindow: 1000000/);
+  assert.match(catalog, /contextWindow: 204800/);
+});

--- a/translations/panel/feature-panel.js
+++ b/translations/panel/feature-panel.js
@@ -359,6 +359,8 @@
 
       const builtins = [
         { id: 'auto', name: 'Auto（自动选择最优）' },
+        { id: 'MiniMax-M3', name: 'MiniMax M3' },
+        { id: 'MiniMax-M2.7', name: 'MiniMax M2.7' },
         { id: 'gpt-4o', name: 'GPT-4o' },
         { id: 'claude-sonnet-4', name: 'Claude Sonnet 4' },
         { id: 'gemini-2.5-pro', name: 'Gemini 2.5 Pro' },

--- a/translations/providers/files/extensions/qingchenyun/provider-catalog.ts
+++ b/translations/providers/files/extensions/qingchenyun/provider-catalog.ts
@@ -15,6 +15,18 @@ export function buildCiyapiProvider(): ModelProviderConfig {
         maxTokens: 16384,
       },
       {
+        id: "MiniMax-M3",
+        name: "MiniMax M3",
+        contextWindow: 1000000,
+        maxTokens: 16384,
+      },
+      {
+        id: "MiniMax-M2.7",
+        name: "MiniMax M2.7",
+        contextWindow: 204800,
+        maxTokens: 16384,
+      },
+      {
         id: "gpt-4o",
         name: "GPT-4o",
         contextWindow: 128000,


### PR DESCRIPTION
Reason: The CiyAPI model registry is missing the MiniMax M3 and MiniMax M2.7 model ids that the current MiniMax lineup requires.

## Changes

- Add `MiniMax-M3` (1,000,000-token context) and `MiniMax-M2.7` (204,800-token context) to the CiyAPI provider catalog in `translations/providers/files/extensions/qingchenyun/provider-catalog.ts`.
- Add `MiniMax-M3` and `MiniMax-M2.7` to the feature-panel builtin model list in `translations/panel/feature-panel.js`.
- Update the MiniMax version table in `docs/guides/models-cn.md` to list the current M3 and M2.7 series.
- Add a regression test in `tests/node/ciyapi-sponsor.test.mjs` asserting both model ids and their context windows appear in the catalog and panel.

## Checks

- `node --test tests/node/ciyapi-sponsor.test.mjs tests/node/prepare-publish-package.test.mjs` — 9 passed.
- `node --check translations/panel/feature-panel.js` — syntax OK.
- `jq empty` validation across `translations/**/*.json` — all OK.
